### PR TITLE
Add nix ecosystem to Dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,10 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "nix"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:


### PR DESCRIPTION
Monitor flake.lock inputs for newer upstream commits, matching the
existing weekly schedule used for uv and github-actions.

https://claude.ai/code/session_01Qsp5XqtJAdtCywqNDcEbSG